### PR TITLE
chore(workflows): update actions versions for more future-proof

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
+      - uses: wagoid/commitlint-github-action@v6
         with:
           configFile: .commitlintrc.yaml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
   issues: write
 
 jobs:
@@ -20,6 +19,8 @@ jobs:
           command: manifest
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-labeling: true
+          skip-github-pull-request: true
       
       # The following steps run if a release was created for any module
       - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           command: manifest

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,4 +1,7 @@
 {
+  "release-type": "go",
+  "draft": false,
+  "separate-pull-requests": false,
   "packages": {
     ".": {
       "release-type": "go",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,10 +1,10 @@
 {
   ".": "0.6.0",
-  "cache": "0.6.0",
-  "drivers/bbolt": "0.6.0",
-  "drivers/cassandra": "0.6.0",
-  "drivers/hashmap": "0.6.0",
-  "drivers/mock": "0.6.0",
-  "drivers/nats": "0.6.0",
-  "drivers/redis": "0.6.0"
+  "cache": "0.6.1",
+  "drivers/bbolt": "0.6.1",
+  "drivers/cassandra": "0.6.1",
+  "drivers/hashmap": "0.6.1",
+  "drivers/mock": "0.6.1",
+  "drivers/nats": "0.6.1",
+  "drivers/redis": "0.6.1"
 }


### PR DESCRIPTION
This pull request updates dependencies in GitHub Actions workflows to use their latest major versions. The updates ensure compatibility with newer features and improvements provided by the respective actions.

Dependency updates in GitHub Actions workflows:

* [`.github/workflows/commitlint.yml`](diffhunk://#diff-6afdd3d5a5b90ed758101676cb67893ad6de8cdd028d0add6c9f94fff0dfc550L11-R11): Updated the `wagoid/commitlint-github-action` from version `v5` to `v6`.
* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L17-R17): Updated the `google-github-actions/release-please-action` from version `v3` to `v4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to use the latest versions for commit message linting and release automation.
  - Improved release configuration to streamline versioning and release processes.
  - Incremented component versions for several modules to reflect recent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->