### PR TITLE
fix(lint): remove redundant lint rule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
           working-directory: ${{ matrix.modules }}
 
           # Optional: golangci-lint command line arguments.
-          args: -E misspell -E revive -E gochecknoinits	-E gofmt -E errname 
+          args: -E misspell -E revive -E gochecknoinits	-E errname 
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
           working-directory: ${{ matrix.modules }}
 
           # Optional: golangci-lint command line arguments.
-          args: -E misspell -E revive -E gochecknoinits	-E errname 
+          args: -E misspell -E revive -E gochecknoinits -E errname
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
Turns out `gofmt` missed the bus in our lint run. No more joyrides for it! 🚌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated linting workflow to remove the gofmt linter from the list of enabled checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->