### PR TITLE
fix(lint): tidy up errcheck and lowercase those errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 coverage/*
 coverage.html
 coverage.out
+
+**/.claude/settings.local.json

--- a/drivers/bbolt/bbolt_test.go
+++ b/drivers/bbolt/bbolt_test.go
@@ -27,7 +27,11 @@ func TestBBoltConnectivity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create test directory - %s", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	testCases := map[string]TestCase{
 		"Happy Path Config": {

--- a/drivers/bbolt/benchmark_test.go
+++ b/drivers/bbolt/benchmark_test.go
@@ -29,7 +29,11 @@ func BenchmarkDrivers(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Got unexpected error when initializing hashmap - %s", err)
 		}
-		defer os.Remove("/tmp/bbolt-benchmark.db")
+		defer func() {
+			if err := os.Remove("/tmp/bbolt-benchmark.db"); err != nil {
+				b.Logf("Failed to remove benchmark db: %v", err)
+			}
+		}()
 		defer db.Close()
 
 		// Setup DB

--- a/drivers/bbolt/common_test.go
+++ b/drivers/bbolt/common_test.go
@@ -17,7 +17,11 @@ func TestInterfaceHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create test directory - %s", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	cfgs := make(map[string]Config)
 	cfgs["Simple BBolt"] = Config{

--- a/drivers/hashmap/common_test.go
+++ b/drivers/hashmap/common_test.go
@@ -19,8 +19,8 @@ func TestInterfaceHappyPath(t *testing.T) {
 	cfgs["HashmapWithYAMLStorage"] = Config{
 		Filename: "testdata/common_test.yml",
 	}
-	defer os.RemoveAll("testdata/common_test.json")
-	defer os.RemoveAll("testdata/common_test.yml")
+	defer os.RemoveAll("testdata/common_test.json") // nolint:errcheck
+	defer os.RemoveAll("testdata/common_test.yml") // nolint:errcheck
 
 	// Loop through valid Configs and validate the driver adheres to the Hord interface
 	for name, cfg := range cfgs {

--- a/drivers/hashmap/hashmap.go
+++ b/drivers/hashmap/hashmap.go
@@ -114,7 +114,7 @@ func (db *Database) Setup() error {
 	if err != nil {
 		return fmt.Errorf("error checking file %q: %w", db.config.Filename, err)
 	}
-	defer file.Close()
+	defer file.Close() // nolint:errcheck
 
 	data, err := io.ReadAll(file)
 	if err != nil {

--- a/drivers/hashmap/hashmap_test.go
+++ b/drivers/hashmap/hashmap_test.go
@@ -37,7 +37,7 @@ func TestSetupCreatesFileIfNotExist(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.ext, func(t *testing.T) {
 			filename := "testdata/empty_file." + tt.ext
-			defer os.RemoveAll(filename)
+			defer os.RemoveAll(filename) // nolint:errcheck
 
 			db, err := Dial(Config{Filename: filename})
 			if err != nil {
@@ -71,7 +71,7 @@ func TestSaveToLocalFileAfterSet(t *testing.T) {
 	for _, tt := range fileTypeCases {
 		t.Run(tt.extension, func(t *testing.T) {
 			filename := "testdata/save_test." + tt.extension
-			defer os.RemoveAll(filename)
+			defer os.RemoveAll(filename) // nolint:errcheck
 
 			db, err := Dial(Config{Filename: filename})
 			if err != nil {
@@ -172,7 +172,7 @@ func TestComplexObjectSaveToFile(t *testing.T) {
 	for _, tt := range fileTypeCases {
 		t.Run(tt.extension, func(t *testing.T) {
 			filename := "testdata/complex_data_test." + tt.extension
-			defer os.RemoveAll(filename)
+			defer os.RemoveAll(filename) // nolint:errcheck
 
 			db, err := Dial(Config{Filename: filename})
 			if err != nil {

--- a/drivers/nats/nats.go
+++ b/drivers/nats/nats.go
@@ -116,7 +116,7 @@ func Dial(cfg Config) (*Database, error) {
 
 	// Validate Bucket
 	if cfg.Bucket == "" || !reBucket.MatchString(cfg.Bucket) {
-		return db, fmt.Errorf("Bucket name is invalid")
+		return db, fmt.Errorf("bucket name is invalid")
 	}
 
 	// Build URL for cluster of servers

--- a/drivers/redis/redis.go
+++ b/drivers/redis/redis.go
@@ -248,7 +248,7 @@ func (db *Database) Get(key string) ([]byte, error) {
 	}
 
 	c := db.pool.Get()
-	defer c.Close()
+	defer c.Close() // nolint:errcheck
 
 	d, err := redis.Bytes(c.Do("GET", key))
 	if err != nil && err != redis.ErrNil {
@@ -277,7 +277,7 @@ func (db *Database) Set(key string, data []byte) error {
 	}
 
 	c := db.pool.Get()
-	defer c.Close()
+	defer c.Close() // nolint:errcheck
 
 	_, err := c.Do("SET", key, data)
 	if err != nil {
@@ -299,7 +299,7 @@ func (db *Database) Delete(key string) error {
 	}
 
 	c := db.pool.Get()
-	defer c.Close()
+	defer c.Close() // nolint:errcheck
 
 	_, err := c.Do("DEL", key)
 	if err != nil {
@@ -316,7 +316,7 @@ func (db *Database) Keys() ([]string, error) {
 		return []string{}, hord.ErrNoDial
 	}
 	c := db.pool.Get()
-	defer c.Close()
+	defer c.Close() // nolint:errcheck
 
 	keys, err := redis.Strings(c.Do("KEYS", "*"))
 	if err != nil {
@@ -336,7 +336,7 @@ func (db *Database) HealthCheck() error {
 	}
 
 	c := db.pool.Get()
-	defer c.Close()
+	defer c.Close() // nolint:errcheck
 
 	_, err := c.Do("PING")
 	if err != nil {
@@ -350,8 +350,8 @@ func (db *Database) Close() {
 	if db == nil || db.pool == nil {
 		return
 	}
-	defer db.pool.Close()
+	defer db.pool.Close() // nolint:errcheck
 	if db.sentinel != nil {
-		defer db.sentinel.Close()
+		defer db.sentinel.Close() // nolint:errcheck
 	}
 }

--- a/drivers/redis/redis_test.go
+++ b/drivers/redis/redis_test.go
@@ -26,7 +26,7 @@ func TestConnectivity(t *testing.T) {
 
 		// Test a connection
 		c := db.pool.Get()
-		defer c.Close()
+		defer c.Close() // nolint:errcheck
 
 		_, err = c.Do("PING")
 		if err != nil {
@@ -70,7 +70,7 @@ func TestConnectivity(t *testing.T) {
 
 		// Test a connection
 		c := db.pool.Get()
-		defer c.Close()
+		defer c.Close() // nolint:errcheck
 
 		_, err = c.Do("PING")
 		if err != nil {

--- a/hord.go
+++ b/hord.go
@@ -99,12 +99,12 @@ type Database interface {
 
 // Common Errors Used by Hord Drivers
 var (
-	ErrInvalidKey      = fmt.Errorf("Key cannot be nil")
-	ErrInvalidData     = fmt.Errorf("Data cannot be empty")
-	ErrNil             = fmt.Errorf("Nil value returned from database")
-	ErrNoDial          = fmt.Errorf("No database connection defined, did you dial?")
-	ErrInvalidDatabase = fmt.Errorf("Database cannot be nil")
-	ErrCacheError      = fmt.Errorf("Cache error")
+	ErrInvalidKey      = fmt.Errorf("key cannot be nil")
+	ErrInvalidData     = fmt.Errorf("data cannot be empty")
+	ErrNil             = fmt.Errorf("nil value returned from database")
+	ErrNoDial          = fmt.Errorf("no database connection defined, did you dial?")
+	ErrInvalidDatabase = fmt.Errorf("database cannot be nil")
+	ErrCacheError      = fmt.Errorf("cache error")
 )
 
 // ValidKey checks if a key is valid.


### PR DESCRIPTION
Added `nolint:errcheck` to suppress error checking warnings that were making our build grumpier than a Monday morning. Also, made error messages lowercase — because we’re all about that chill and consistency vibe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized error message capitalization to start with lowercase letters across various components.
  - Added comments to suppress linter warnings for unchecked errors in deferred cleanup and close operations.

- **Chores**
  - Updated the ignore list to exclude certain local settings files from version control.

- **Bug Fixes**
  - Improved error handling in test cleanup steps by logging failures when file or directory removal does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->