### PR TITLE
ci: fix release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           command: manifest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the release process by changing the source of the `release-please-action` to a new repository.

Workflow update:

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L16-R16): Updated the `release-please-action` to use `googleapis/release-please-action@v4` instead of `google-github-actions/release-please-action@v4`. This change likely reflects a repository or ownership update for the action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow to use a different source for the release automation action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->